### PR TITLE
Uncommented Zookeper Prepare task in customize.yml

### DIFF
--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -73,9 +73,9 @@
       notify: restart_nifi
   when: authorizers | length
 
-# - name: Prepare Zookeeper
-#   include: zookeeper.yml
-#   when:
-#     - nifi_properties['nifi.state.management.embedded.zookeeper.start'] is defined
-#     - nifi_properties['nifi.state.management.embedded.zookeeper.start'] | bool
-#   notify: restart_nifi
+- name: Prepare Zookeeper
+  include: zookeeper.yml
+  when:
+    - nifi_properties['nifi.state.management.embedded.zookeeper.start'] is defined
+    - nifi_properties['nifi.state.management.embedded.zookeeper.start'] | bool
+  notify: restart_nifi


### PR DESCRIPTION
The task used to prepare Zookeper contained within "customize.yml" has been uncommented