### PR TITLE
20 Added task to customize authorizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ Basic 3 node NiFi cluster using embedded Zookeeper:
     login_identity_providers:
       /loginIdentityProviders/provider/identifier: single-user-provider
       /loginIdentityProviders/provider/class: org.apache.nifi.authentication.single.user.SingleUserLoginIdentityProvider
-    authorizers_user_group_providers: 0
+
     authorizers:
-      /authorizers/authorizer/identifier: single-user-authorizer
-      /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer
+      authorizer:
+        /authorizers/authorizer/identifier: single-user-authorizer
+        /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer
     state_management:
       /stateManagement/cluster-provider/property[@name="Connect String"]: "{{ nifi_properties['nifi.zookeeper.connect.string'] }}"
     # Assuming nifi_server1 = 192.168.1.10, nifi_server2 = 192.168.1.11, nifi_server3 = 192.168.1.12
@@ -148,20 +149,25 @@ Secure single node NiFi instance with LDAP:
       /loginIdentityProviders/provider/property[@name="User Search Filter"]: sAMAccountName={0}
       /loginIdentityProviders/provider/property[@name="Identity Strategy"]: USE_DN
       /loginIdentityProviders/provider/property[@name="Authentication Expiration"]: 12 hours
-    authorizers_user_group_providers: 1
+
     authorizers:
-      /authorizers/userGroupProvider[1]/identifier: file-user-group-provider
-      /authorizers/userGroupProvider[1]/class: org.apache.nifi.authorization.FileUserGroupProvider
-      /authorizers/userGroupProvider[1]/property[@name="Users File"]: "{{ nifi_config_dirs.external_config }}/users.xml"
-      /authorizers/userGroupProvider[1]/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
-      /authorizers/accessPolicyProvider/identifier: file-access-policy-provider
-      /authorizers/accessPolicyProvider/class: org.apache.nifi.authorization.FileAccessPolicyProvider
-      /authorizers/accessPolicyProvider/property[@name="User Group Provider"]: file-user-group-provider
-      /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_config_dirs.external_config }}/authorizations.xml"
-      /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people,dc=example,dc=com
-      /authorizers/authorizer/identifier: managed-authorizer
-      /authorizers/authorizer/class: org.apache.nifi.authorization.StandardManagedAuthorizer
-      /authorizers/authorizer/property[@name="Access Policy Provider"]: file-access-policy-provider
+      userGroupProviders:
+        /authorizers/userGroupProvider/identifier: file-user-group-provider
+        /authorizers/userGroupProvider/class: org.apache.nifi.authorization.FileUserGroupProvider
+        /authorizers/userGroupProvider/property[@name="Users File"]: "{{ nifi_config_dirs.external_config }}/users.xml"
+        /authorizers/userGroupProvider/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
+
+      accessPolicyProviders:
+        /authorizers/accessPolicyProvider/identifier: file-access-policy-provider
+        /authorizers/accessPolicyProvider/class: org.apache.nifi.authorization.FileAccessPolicyProvider
+        /authorizers/accessPolicyProvider/property[@name="User Group Provider"]: file-user-group-provider
+        /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_config_dirs.  external_config }}/authorizations.xml"
+        /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people,dc=example,dc=com
+      
+      authorizer:
+        /authorizers/authorizer/identifier: managed-authorizer
+        /authorizers/authorizer/class: org.apache.nifi.authorization.StandardManagedAuthorizer
+        /authorizers/authorizer/property[@name="Access Policy Provider"]: file-access-policy-provider
 ```
 
 Secure 3 node NiFi cluster with LDAP using embedded zookeeper:
@@ -208,27 +214,33 @@ Secure 3 node NiFi cluster with LDAP using embedded zookeeper:
       /loginIdentityProviders/provider/property[@name="User Search Filter"]: sAMAccountName={0}
       /loginIdentityProviders/provider/property[@name="Identity Strategy"]: USE_DN
       /loginIdentityProviders/provider/property[@name="Authentication Expiration"]: 12 hours
-    authorizers_user_group_providers: 1
+
     authorizers:
-      /authorizers/userGroupProvider[1]/identifier: file-user-group-provider
-      /authorizers/userGroupProvider[1]/class: org.apache.nifi.authorization.FileUserGroupProvider
-      /authorizers/userGroupProvider[1]/property[@name="Users File"]: "{{ nifi_config_dirs.external_config }}/users.xml"
-      /authorizers/userGroupProvider[1]/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
-      # Use the full DN of the node certificates here
-      /authorizers/userGroupProvider[1]/property[@name="Initial User Identity 2"]: CN=nifi_server1.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/userGroupProvider[1]/property[@name="Initial User Identity 3"]: CN=nifi_server2.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/userGroupProvider[1]/property[@name="Initial User Identity 4"]: CN=nifi_server3.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/accessPolicyProvider/identifier: file-access-policy-provider
-      /authorizers/accessPolicyProvider/class: org.apache.nifi.authorization.FileAccessPolicyProvider
-      /authorizers/accessPolicyProvider/property[@name="User Group Provider"]: file-user-group-provider
-      /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_config_dirs.external_config }}/authorizations.xml"
-      /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people,dc=example,dc=com
-      /authorizers/accessPolicyProvider/property[@name="Node Identity 1"]: CN=nifi_server1.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/accessPolicyProvider/property[@name="Node Identity 2"]: CN=nifi_server2.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/accessPolicyProvider/property[@name="Node Identity 3"]: CN=nifi_server3.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
-      /authorizers/authorizer/identifier: managed-authorizer
-      /authorizers/authorizer/class: org.apache.nifi.authorization.StandardManagedAuthorizer
-      /authorizers/authorizer/property[@name="Access Policy Provider"]: file-access-policy-provider
+      userGroupProviders:
+        /authorizers/userGroupProvider/identifier: file-user-group-provider
+        /authorizers/userGroupProvider/class: org.apache.nifi.authorization.FileUserGroupProvider
+        /authorizers/userGroupProvider/property[@name="Users File"]: "{{ nifi_config_dirs.external_config }}/users.xml"
+        /authorizers/userGroupProvider/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
+        # Use the full DN of the node certificates here
+        /authorizers/userGroupProvider/property[@name="Initial User Identity 2"]: CN=nifi_server1.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+        /authorizers/userGroupProvider/property[@name="Initial User Identity 3"]: CN=nifi_server2.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+        /authorizers/userGroupProvider/property[@name="Initial User Identity 4"]: CN=nifi_server3.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+      
+      accessPolicyProviders:
+        /authorizers/accessPolicyProvider/identifier: file-access-policy-provider
+        /authorizers/accessPolicyProvider/class: org.apache.nifi.authorization.FileAccessPolicyProvider
+        /authorizers/accessPolicyProvider/property[@name="User Group Provider"]: file-user-group-provider
+        /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_config_dirs.external_config }}/authorizations.xml"
+        /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people, dc=example,dc=com
+        /authorizers/accessPolicyProvider/property[@name="Node Identity 1"]: CN=nifi_server1.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+        /authorizers/accessPolicyProvider/property[@name="Node Identity 2"]: CN=nifi_server2.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+        /authorizers/accessPolicyProvider/property[@name="Node Identity 3"]: CN=nifi_server3.example.com, O=ExampleLLC, L=Saint Louis, ST=Missouri, C=US
+
+      authorizer:
+        /authorizers/authorizer/identifier: managed-authorizer
+        /authorizers/authorizer/class: org.apache.nifi.authorization.StandardManagedAuthorizer
+        /authorizers/authorizer/property[@name="Access Policy Provider"]: file-access-policy-provider
+
     state_management:
       /stateManagement/cluster-provider/property[@name="Connect String"]: "{{ nifi_properties['nifi.zookeeper.connect.string'] }}"
     # Assuming nifi_server1 = 192.168.1.10, nifi_server2 = 192.168.1.11, nifi_server3 = 192.168.1.12

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,14 +55,13 @@ login_identity_providers:
 state_management:
   /stateManagement/local-provider/property[@name="Directory"]: "{{ nifi_config_dirs.external_config }}/state/local"
 
-# Specify how many userGroupProviders are used authorizers.xml.
-authorizers_user_group_providers: 0
 
 # Specify any property from authorizers.xml here.
 # Use XPath expressions as keys.
 authorizers:
-  /authorizers/authorizer/identifier: single-user-authorizer
-  /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer
+  authorizer:
+    /authorizers/authorizer/identifier: single-user-authorizer
+    /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer
 
 # The following zookeeper properties are only used if
 # nifi_properties.nifi.state.management.embedded.zookeeper.start == true

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -63,14 +63,31 @@
       template:
         src: "templates/authorizers.xml.j2"
         dest: "{{ nifi_config_dirs.home }}/conf/authorizers.xml"
-    - name: Add properties to authorizers.xml
+    - name: Add userGroupProvider to authorizers.xml
       xml:
         path: "{{ nifi_config_dirs.home }}/conf/authorizers.xml"
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
         pretty_print: yes
-      with_dict: "{{ authorizers }}"
-      notify: restart_nifi
+      with_dict: "{{ authorizers.userGroupProviders }}"
+      when: authorizers.userGroupProviders | length
+    - name: Add accessPolicyProvider to authorizers.xml
+      xml:
+        path: "{{ nifi_config_dirs.home }}/conf/authorizers.xml"
+        xpath: "{{ item.key }}"
+        value: "{{ item.value }}"
+        pretty_print: yes
+      with_dict: "{{ authorizers.accessPolicyProviders }}"
+      when: authorizers.accessPolicyProviders | length
+    - name: Add authorizer to authorizers.xml
+      xml:
+        path: "{{ nifi_config_dirs.home }}/conf/authorizers.xml"
+        xpath: "{{ item.key }}"
+        value: "{{ item.value }}"
+        pretty_print: yes
+      with_dict: "{{ authorizers.authorizer }}"
+      when: authorizers.authorizer | length
+  notify: restart_nifi
   when: authorizers | length
 
 - name: Prepare Zookeeper

--- a/templates/authorizers.xml.j2
+++ b/templates/authorizers.xml.j2
@@ -2,8 +2,5 @@
 
 <!-- ANSIBLE MANAGED FILE. DO NOT EDIT -->
 
-<authorizers>
-    {% for i in range(authorizers_user_group_providers) %}
-        <userGroupProvider/>
-    {% endfor %}
-</authorizers>
+<authorizers/>
+


### PR DESCRIPTION
The Ansible role has been modified to update the authorizers.xml file according to specific configuration passed from the hosts file.

In particular the 3 sub-tasks that were added to the serve the purpose of:
- populating the authorizers.xml file with a node named "userGroupProvider"
- populating the authorizers.xml file with a node named "accessPolicyProvider"
- populating the authorizers.xml file with a node named "authorizer"

