### PR TITLE
Fix authorizers defaults value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,8 +59,8 @@ state_management:
 # Specify any property from authorizers.xml here.
 # Use XPath expressions as keys.
 authorizers:
-  userGroupProviders:
-  accessPolicyProviders:
+  userGroupProviders: {}
+  accessPolicyProviders: {}
   authorizer:
     /authorizers/authorizer/identifier: single-user-authorizer
     /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,8 @@ state_management:
 # Specify any property from authorizers.xml here.
 # Use XPath expressions as keys.
 authorizers:
+  userGroupProviders:
+  accessPolicyProviders:
   authorizer:
     /authorizers/authorizer/identifier: single-user-authorizer
     /authorizers/authorizer/class: org.apache.nifi.authorization.single.user.SingleUserAuthorizer


### PR DESCRIPTION
The default structure of the `authorizers` dict must specify all nested keys, otherwise the role will break when they are not present.