### PR TITLE
Add task to create zookeeper-jaas.conf file 

### DIFF
--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -91,11 +91,10 @@
   when: authorizers | length
 
 
-- name: Update zookeeper-jaas.conf
-  blockinfile:
-    path: "{{ nifi_config_dirs.home }}/conf/zookeeper-jaas.conf"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    block: |
+- name: Create zookeeper-jaas.conf
+  copy:
+    dest: "{{ nifi_config_dirs.home }}/conf/zookeeper-jaas.conf"
+    content: |
       Client {
         com.sun.security.auth.module.Krb5LoginModule required
         useKeyTab=true

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -90,6 +90,24 @@
   notify: restart_nifi
   when: authorizers | length
 
+
+- name: Update zookeeper-jaas.conf
+  blockinfile:
+    path: "{{ nifi_config_dirs.home }}/conf/zookeeper-jaas.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    block: |
+      Client {
+        com.sun.security.auth.module.Krb5LoginModule required
+        useKeyTab=true
+        keyTab="{{ keytab_path }}"
+        storeKey=true
+        useTicketCache=false
+        principal="{{ kerberos_principal }}";
+      };
+  vars:
+    keytab_path: "{{ nifi_properties['nifi.kerberos.keytab.location'] }}"
+    principal_name: "nifi/{{ inventory_hostname }}@CORP.OPENFIBER.IT"
+
 - name: Prepare Zookeeper
   include: zookeeper.yml
   when:

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -98,14 +98,11 @@
       Client {
         com.sun.security.auth.module.Krb5LoginModule required
         useKeyTab=true
-        keyTab="{{ keytab_path }}"
+        keyTab="{{ nifi_properties['nifi.kerberos.keytab.location'] }}"
         storeKey=true
         useTicketCache=false
-        principal="{{ principal_name }}";
+        principal="{{ nifi_kerberos_principal }}";
       };
-  vars:
-    keytab_path: "{{ nifi_properties['nifi.kerberos.keytab.location'] }}"
-    principal_name: "nifi/{{ inventory_hostname }}@CORP.OPENFIBER.IT"
   when: nifi_zookeeper_cluster
 
 - name: Prepare Zookeeper

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -102,7 +102,7 @@
         keyTab="{{ keytab_path }}"
         storeKey=true
         useTicketCache=false
-        principal="{{ kerberos_principal }}";
+        principal="{{ principal_name }}";
       };
   vars:
     keytab_path: "{{ nifi_properties['nifi.kerberos.keytab.location'] }}"

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -106,6 +106,7 @@
   vars:
     keytab_path: "{{ nifi_properties['nifi.kerberos.keytab.location'] }}"
     principal_name: "nifi/{{ inventory_hostname }}@CORP.OPENFIBER.IT"
+  when: nifi_zookeeper_cluster
 
 - name: Prepare Zookeeper
   include: zookeeper.yml


### PR DESCRIPTION
zookeeper-jaas.conf file is required when deploying a kerberized zookeeper nifi installation. A new task in customize.yml creates such a file with the proper configurations